### PR TITLE
Fixing issue with rapid relay state changes and temperature jitter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,14 +9,23 @@
 DHT dht = DHT(DHTPIN, DHTTYPE);
 
 // Initialize / define vars for the temperature readings
-int temp = 0;
+#define T_LENGTH 10 // Number of temperatures to use for averaging
+#define T_DELAY 2000 // wait between tem readings (the sensor is slow)
+unsigned long t_last_read = 0; // Keep track of the last time the temp was read
+int t_index = -1; // Start the index at -1 so we can catch it the first time around and pad the array
+float temp[T_LENGTH];	// We'll use an array of floats to generate the average temp
+float temp_avg = 0;
 int humid = 0;
 int temp_set = 65;
-int relay_state = 0;
 
 // Setup for the relay
 #define RELAYPIN 3    // Pin D3
-
+#define RELAY_ON 1
+#define RELAY_OFF 0
+#define RELAY_DELAY 300000 // 300,000 ms (5 minute) delay
+int relay_state = RELAY_OFF;
+int relay_desired_state = RELAY_OFF;
+unsigned long relay_last_change = 0;
 
 // select the pins used on the LCD panel
 LiquidCrystal lcd(8, 9, 4, 5, 6, 7);
@@ -54,32 +63,67 @@ void set_backlight()
 
 }
 
-// read the buttons
 int read_LCD_buttons()
 {
 	adc_key_in = analogRead(0);      // read the value from the sensor 
 	// my buttons when read are centered at these valies: 0, 144, 329, 504, 741
 	// we add approx 50 to those values and check to see if we are close
 	if (adc_key_in > 1000) return btnNONE; // We make this the 1st option for speed reasons since it will be the most likely result
-	if (adc_key_in < 50)   return btnRIGHT;  
-	if (adc_key_in < 195)  return btnUP; 
-	if (adc_key_in < 380)  return btnDOWN; 
-	if (adc_key_in < 555)  return btnLEFT; 
-	if (adc_key_in < 790)  return btnSELECT;   
+	if (adc_key_in < 50)   return btnRIGHT;
+	if (adc_key_in < 195)  return btnUP;
+	if (adc_key_in < 380)  return btnDOWN;
+	if (adc_key_in < 555)  return btnLEFT;
+	if (adc_key_in < 790)  return btnSELECT;
 
 	return btnNONE;  // when all others fail, return this...
 }
 
-void readtemp()
+float get_temp()
 {
-	temp = round(dht.readTemperature(READ_F));
+	float temp_reading = dht.readTemperature(READ_F);
+	t_last_read = millis();
+	// Sanity check the returned value; fail to 0
+	return isnan(temp_reading) ? 0 : temp_reading;
+}
+
+void calculate_temp()
+{
+	// Check our startup boundary condition
+	if (t_index == -1) {
+		float temp_current = get_temp();
+		for(int i = 0; i < T_LENGTH; i++) {
+			temp[i] = temp_current;
+		}
+		t_index = 0;
+		temp_avg = temp_current;
+	} else {
+		// Check if we've waited long enough for the next reading
+		if ((millis() - t_last_read) >= T_DELAY) {
+			// Increment the array index; reset to 0 if we're over the end
+			if (++t_index >= T_LENGTH) {
+				t_index = 0;
+			}
+
+			float temp_current = get_temp();
+			temp[t_index] = temp_current;
+
+			// Get the average temp from the array (last T_LENGTH readings)
+			float temp_sum = 0;
+			for(int j = 0; j < T_LENGTH; j++) {
+				temp_sum += temp[j];
+			}
+			temp_avg = temp_sum / T_LENGTH;
+		}
+	}
+
+	// Read the humidity (no fancy processing, we don't really care about it much)
 	humid = round(dht.readHumidity());
 }
 
 void printtemp()
 {
 	lcd.setCursor(6,0);
-	lcd.print(temp);
+	lcd.print(round(temp_avg));
 	lcd.print("F ");
 	lcd.print(humid);
 	lcd.print("%   ");
@@ -94,32 +138,53 @@ void printtemp_set()
 
 void setrelay()
 {
-	lcd.setCursor(10,1);
-	if (temp_set > temp) {
-		relay_state = 1;
-		digitalWrite(RELAYPIN, HIGH);
-		lcd.print("ON ");
+	if (temp_set > temp_avg) {
+		// Actual temp lower than desired temp, we want the heat on
+		relay_desired_state = RELAY_ON;
 	} else {
-		relay_state = 0;
-		digitalWrite(RELAYPIN, LOW);
-		lcd.print("OFF");
+		// Actual temp equal to, or higher than desired temp, we want the heat off
+		relay_desired_state = RELAY_OFF;
+	}
+
+	if (relay_desired_state != relay_state) {
+		// Desired state difers from actual state; flip the actual state
+		lcd.setCursor(10,1);
+		if ((millis() - relay_last_change) >= RELAY_DELAY) {
+			relay_state = relay_desired_state;
+			digitalWrite(RELAYPIN, relay_state);
+			relay_last_change = millis();
+			// Display the relay state
+			if (relay_state == RELAY_ON) {
+				lcd.print("ON ");
+			} else {
+				lcd.print("OFF");
+			}
+		} else {
+			// We want to change the state, but we're in a loackout period
+			lcd.print("LCK");
+		}
 	}
 }
 
 void setup()
 {
 	pinMode(RELAYPIN, OUTPUT);
-	digitalWrite(RELAYPIN, LOW);
-	lcd.begin(16, 2);              // start the library
+	digitalWrite(RELAYPIN, LOW);		// init the relay to 'OFF'
+	lcd.begin(16, 2);								// start the library
 	dht.begin();
 	init_display();
 	pinMode(BACKLIGHT_PIN, OUTPUT);
 	set_backlight();
+	// Fake the first relay state change so we can change the relay state 
+	// without waiting 5 minutes after startup
+	relay_last_change = millis() - RELAY_DELAY;
+	lcd.setCursor(10,1);
+	lcd.print("OFF");
 }
 
 void loop()
 {
-	readtemp();
+	calculate_temp();
 	printtemp();
 	printtemp_set();
 	setrelay();
@@ -144,7 +209,6 @@ void loop()
 			}
 		case btnUP:
 			{
-				//lcd.print("UP    ");
 				temp_set++;
 				printtemp_set();
 				delay(BTNDELAY);
@@ -152,7 +216,6 @@ void loop()
 			}
 		case btnDOWN:
 			{
-				//lcd.print("DOWN  ");
 				temp_set--;
 				printtemp_set();
 				delay(BTNDELAY);
@@ -163,13 +226,11 @@ void loop()
 				//lcd.print("SELECT");
 				break;
 			}
-			/*
-				 case btnNONE:
-				 {
-				 lcd.print("NONE  ");
-				 break;
-				 }
-				 */
+		case btnNONE:
+			{
+				//lcd.print("NONE  ");
+				break;
+			}
 	}
 
 }


### PR DESCRIPTION
* readtemp function is now calculate_temp & get_temp. Instead of
returning an integer temperature wth every loop iteration we now only
read the temperature every 2000ms and add the value to an array of the
previous 9 readings, then return the average of the array. This should
reduce jitter in the temperature reading
* setrelay function now checks against the last state change and enters
a lockout state if the relay state has changed within the last 300,000ms
to prevent the relay from cycling on/off rapidly