### PR TITLE
Changing DHT sensor to default to DHT-22

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -1,6 +1,8 @@
 // Set up the DHT temp/humidity sensor
+#ifndef  DHTTYPE
+#define  DHTTYPE DHT22                          /* Default to DHT22 */
+#endif                                          /* ----- #ifndef DHTTYPE  ----- */
 #define DHTPIN 2        // Pin D2
-#define DHTTYPE DHT11   // DHT 11
 #define READ_F true
 
 // Initialize / define vars for the temperature readings


### PR DESCRIPTION
Swapping hardware sensor DHT-11 for DHT-22; hopefully this will reduce some of the temperature jitter.

Setting the #define up to _default_ to DHT22. Override with preprocessor argument if required.