### PR TITLE
Support display module version 2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,11 +7,25 @@
 ;
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/page/projectconf.html
+[platformio]
+env_default = prod
 
-[env:uno]
+[common_env_data]
 platform = atmelavr
-board = uno
 framework = arduino
 lib_deps =
   DHT sensor library
   Adafruit Unified Sensor
+
+[env:prod]
+platform = ${common_env_data.platform}
+board = uno
+framework = ${common_env_data.framework}
+lib_deps = ${common_env_data.lib_deps}
+
+[env:test]
+platform = ${common_env_data.platform}
+board = uno
+framework = ${common_env_data.framework}
+lib_deps = ${common_env_data.lib_deps}
+build_flags = -DDISPLAY_V2 -DDHTTYPE=DHT11

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,14 +37,12 @@ void set_backlight()
 int read_LCD_buttons()
 {
 	adc_key_in = analogRead(0);      // read the value from the sensor 
-	// my buttons when read are centered at these valies: 0, 144, 329, 504, 741
-	// we add approx 50 to those values and check to see if we are close
-	if (adc_key_in > 1000) return btnNONE; // We make this the 1st option for speed reasons since it will be the most likely result
-	if (adc_key_in < 50)   return btnRIGHT;
-	if (adc_key_in < 195)  return btnUP;
-	if (adc_key_in < 380)  return btnDOWN;
-	if (adc_key_in < 555)  return btnLEFT;
-	if (adc_key_in < 790)  return btnSELECT;
+	if (adc_key_in > THRESH_NONE)		return btnNONE; // Most likely result first
+	if (adc_key_in < THRESH_RIGHT)	return btnRIGHT;
+	if (adc_key_in < THRESH_UP)			return btnUP;
+	if (adc_key_in < THRESH_DOWN)		return btnDOWN;
+	if (adc_key_in < THRESH_LEFT)		return btnLEFT;
+	if (adc_key_in < THRESH_SELECT)	return btnSELECT;
 
 	return btnNONE;  // when all others fail, return this...
 }

--- a/src/main.h
+++ b/src/main.h
@@ -2,6 +2,7 @@
 #ifndef  DHTTYPE
 #define  DHTTYPE DHT22                          /* Default to DHT22 */
 #endif                                          /* ----- #ifndef DHTTYPE  ----- */
+
 #define DHTPIN 2        // Pin D2
 #define READ_F true
 
@@ -32,6 +33,26 @@ struct Relay {
 #define BACKLIGHT_PIN 10    // Backlight PWM pin
 
 // define some values used by the panel and buttons
+/* The display / button module has two versions with differing
+ * button press voltages. We'll default to Version 1.0 values,
+ * but set values for Version 2.0 if DISPLAY_V2 is defined
+ */
+#ifndef DISPLAY_V2
+#define THRESH_RIGHT	50
+#define THRESH_UP			195
+#define THRESH_DOWN		380
+#define THRESH_LEFT		555
+#define THRESH_SELECT	790
+#define THRESH_NONE		1000
+#else
+#define THRESH_RIGHT	50
+#define THRESH_UP			250
+#define THRESH_DOWN		450
+#define THRESH_LEFT		650
+#define THRESH_SELECT	850
+#define THRESH_NONE		1000
+#endif																					/* ----- #ifndef DISPLAY_V2 -----*/
+
 #define btnRIGHT  0
 #define btnUP     1
 #define btnDOWN   2


### PR DESCRIPTION
The display module (VMA203) has two versions, which output different voltages for each of the buttons. This branch allows compile time selection of either version (defaulting to 1.0)

* Refactored read_LCD_buttons to use macros
* Defined default macro values for display v1
* Define optional macro values for display v2
* Refactored platformio config with prod and stg envs